### PR TITLE
Added a proof of concept for testing JSON

### DIFF
--- a/test/resources/ValidIndividual.json
+++ b/test/resources/ValidIndividual.json
@@ -1,0 +1,12 @@
+{
+  "title": "Dr",
+  "givenName": "Leo",
+  "otherName": null,
+  "familyName": "Spaceman",
+  "dateOfBirth": "1800-01-01",
+  "dateOfDeath": null,
+  "nino": null,
+  "passport": "{PASSPORT}",
+  "correspondenceAddress": "{ADDRESS}",
+  "telephoneNumber": null
+}

--- a/test/resources/ValidPassport.json
+++ b/test/resources/ValidPassport.json
@@ -1,0 +1,5 @@
+{
+  "identifier": "IDENTIFIER",
+  "expiryDate": "2020-01-01",
+  "countryOfIssue": "UK"
+}

--- a/test/uk/gov/hmrc/trustregistration/TestResourceSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/TestResourceSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.trustregistration
+
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.trustregistration.models.{Passport, Trustee}
+
+import scala.io.Source
+
+class TestResourceSpec extends UnitSpec {
+
+  val validPassportJson = Source.fromFile(getClass.getResource("/ValidPassport.json").getPath).mkString
+
+  val validIndividualJson = Source
+                              .fromFile(getClass.getResource("/ValidIndividual.json").getPath)
+                              .mkString
+                              .replace("\"{PASSPORT}\"", validPassportJson)
+                              .replace("\"{ADDRESS}\"", "null")
+
+  "Test Suites" should {
+
+    "be able to pull in test resources" in {
+      val result = Json.parse(validPassportJson).asOpt[Passport].get
+
+      result.identifier shouldBe "IDENTIFIER"
+    }
+
+    "be able to combine test resources" in {
+      val result = Json.parse(validIndividualJson).asOpt[Trustee].get
+
+      result.givenName shouldBe "Leo"
+      result.passport.get.identifier shouldBe "IDENTIFIER"
+    }
+
+  }
+
+}


### PR DESCRIPTION
One of the issues when working on the tests for get trustees is that we ended up
with a great deal of JSON within our test suite. We decided it'd be better if we
could have external JSON files with examples of good & bad JSON which we could
pull in and reference from our tests.

This branch proves that we can do that and gives an idea for a possible
implementation within our tests. When we refactor the get trustees spec we can
refine it further based on real world usage.