### PR TITLE
CHANGES AFTER GET TRUSTEES#45 PULL REQUEST COMMENTS

### DIFF
--- a/app/uk/gov/hmrc/trustregistration/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/trustregistration/connectors/DesConnector.scala
@@ -132,7 +132,7 @@ trait DesConnector extends ServicesConfig with RawResponseReads {
 
     val result: Future[HttpResponse] = httpGet.GET[HttpResponse](uri)(httpReads, implicitly)
 
-    result.map(f = f => {
+    result.map(f => {
       f.status match {
         case 200 => {
           val trustees = f.json.asOpt[List[Trustee]]

--- a/app/uk/gov/hmrc/trustregistration/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/trustregistration/connectors/DesConnector.scala
@@ -138,7 +138,7 @@ trait DesConnector extends ServicesConfig with RawResponseReads {
           val trustees = f.json.asOpt[List[Trustee]]
 
           trustees match {
-            case Some(value: List[Trustee]) => GetTrusteeSuccessResponse(value)
+            case Some(value: List[Trustee]) => GetSuccessResponse(value)
             case _ => InternalServerErrorResponse
           }
         }

--- a/app/uk/gov/hmrc/trustregistration/models/Responses.scala
+++ b/app/uk/gov/hmrc/trustregistration/models/Responses.scala
@@ -21,4 +21,4 @@ object SuccessResponse extends TrustResponse
 object BadRequestResponse extends TrustResponse
 object NotFoundResponse extends TrustResponse
 object InternalServerErrorResponse extends TrustResponse
-case class GetTrusteeSuccessResponse[T](payload:T) extends TrustResponse
+case class GetSuccessResponse[T](payload:T) extends TrustResponse

--- a/app/uk/gov/hmrc/trustregistration/models/Responses.scala
+++ b/app/uk/gov/hmrc/trustregistration/models/Responses.scala
@@ -21,4 +21,4 @@ object SuccessResponse extends TrustResponse
 object BadRequestResponse extends TrustResponse
 object NotFoundResponse extends TrustResponse
 object InternalServerErrorResponse extends TrustResponse
-case class GetTrusteeSuccessResponse(trustees:List[Trustee]) extends TrustResponse
+case class GetTrusteeSuccessResponse[T](payload:T) extends TrustResponse

--- a/app/uk/gov/hmrc/trustregistration/models/Trustee.scala
+++ b/app/uk/gov/hmrc/trustregistration/models/Trustee.scala
@@ -19,8 +19,17 @@ package uk.gov.hmrc.trustregistration.models
 import org.joda.time.DateTime
 import play.api.libs.json.{Json, Reads}
 
-case class Trustee(title: String, givenName: String, familyName: String, dateOfBirth: DateTime,otherName: Option[String]= None, nino: Option[String]= None,
-                   dateOfDeath: Option[DateTime]= None, telephoneNumber: Option[String]= None, passport: Option[Passport] = None, correspondenceAddress: Option[Address] = None)
+case class Trustee(
+     title: String,
+     givenName: String,
+     familyName: String,
+     dateOfBirth: DateTime,
+     otherName: Option[String]= None,
+     nino: Option[String]= None,
+     dateOfDeath: Option[DateTime]= None,
+     telephoneNumber: Option[String]= None,
+     passport: Option[Passport] = None,
+     correspondenceAddress: Option[Address] = None)
 
 object Trustee {
   implicit val dateReads: Reads[DateTime] = Reads.of[String] map (new DateTime(_))

--- a/test/uk/gov/hmrc/trustregistration/connectors/DES/CloseTrustSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/connectors/DES/CloseTrustSpec.scala
@@ -31,9 +31,7 @@ class CloseTrustSpec extends PlaySpec with OneAppPerSuite with DESConnectorMocks
   "Close Trust endpoint" must {
     "Return a BadRequestResponse" when {
       "a bad requested is returned from DES for the call to close-trust" in {
-        when (mockHttpPut.PUT[String,HttpResponse](Matchers.any(),Matchers.any())
-          (Matchers.any(),Matchers.any(),Matchers.any())).
-          thenReturn(Future.successful(HttpResponse(400)))
+        setHttpResponse(Future.successful(HttpResponse(400)))
         val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
         result mustBe BadRequestResponse
       }
@@ -41,52 +39,44 @@ class CloseTrustSpec extends PlaySpec with OneAppPerSuite with DESConnectorMocks
 
     "Return a NotFoundResponse" when {
       "a 404 is returned from DES for the call to close-trust" in {
-        when (mockHttpPut.PUT[String,HttpResponse](Matchers.any(),Matchers.any())
-          (Matchers.any(),Matchers.any(),Matchers.any())).
-          thenReturn(Future.successful(HttpResponse(404)))
+        setHttpResponse(Future.successful(HttpResponse(404)))
         val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
         result mustBe NotFoundResponse
       }
     }
 
-    "Return a InternalServerError" when {
-      "a 500 is returned from DES for the call to close-trust" in {
-        when (mockHttpPut.PUT[String,HttpResponse](Matchers.any(),Matchers.any())
-          (Matchers.any(),Matchers.any(),Matchers.any())).
-          thenReturn(Future.successful(HttpResponse(500)))
-        val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
-        result mustBe InternalServerErrorResponse
-      }
-    }
-
-    "Return a InternalServerError" when {
-      "a 418 is returned from DES for the call to close-trust" in {
-        when (mockHttpPut.PUT[String,HttpResponse](Matchers.any(),Matchers.any())
-          (Matchers.any(),Matchers.any(),Matchers.any())).
-          thenReturn(Future.successful(HttpResponse(418)))
-        val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
-        result mustBe InternalServerErrorResponse
-      }
-    }
-
     "Return a SuccessResponse" when {
       "a 204 is returned from DES for the call to close-trust" in {
-        when (mockHttpPut.PUT[String,HttpResponse](Matchers.any(),Matchers.any())
-          (Matchers.any(),Matchers.any(),Matchers.any())).
-          thenReturn(Future.successful(HttpResponse(204)))
+        setHttpResponse(Future.successful(HttpResponse(204)))
         val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
         result mustBe SuccessResponse
       }
     }
 
-    "Return an InternalServerErrorResponse" when {
+    "Return a InternalServerError" when {
+      "a 418 is returned from DES for the call to close-trust" in {
+        setHttpResponse(Future.successful(HttpResponse(418)))
+        val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
+        result mustBe InternalServerErrorResponse
+      }
+
       "the call to DES fails on the call to close-trust" in {
-        when (mockHttpPut.PUT[String,HttpResponse](Matchers.any(),Matchers.any())
-          (Matchers.any(),Matchers.any(),Matchers.any())).
-          thenReturn(Future.failed(Upstream4xxResponse("Error", 418, 400)))
+        setHttpResponse(Future.failed(Upstream4xxResponse("Error", 418, 400)))
+        val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
+        result mustBe InternalServerErrorResponse
+      }
+
+      "a 500 is returned from DES for the call to close-trust" in {
+        setHttpResponse(Future.successful(HttpResponse(500)))
         val result = Await.result(SUT.closeTrust("1234"),Duration.Inf)
         result mustBe InternalServerErrorResponse
       }
     }
+  }
+
+  def setHttpResponse(response: Future[HttpResponse]): Unit = {
+    when (mockHttpPut.PUT[String,HttpResponse](Matchers.any(),Matchers.any())
+      (Matchers.any(),Matchers.any(),Matchers.any())).
+      thenReturn(response)
   }
 }

--- a/test/uk/gov/hmrc/trustregistration/connectors/DES/GetTrusteesSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/connectors/DES/GetTrusteesSpec.scala
@@ -36,7 +36,7 @@ class GetTrusteesSpec extends PlaySpec with OneAppPerSuite with DESConnectorMock
       "DES returns a 200 response with an empty array" in {
         when (mockHttpGet.GET[HttpResponse](Matchers.any())(Matchers.any(),Matchers.any())).thenReturn(Future.successful(HttpResponse(200, Some(Json.parse("[]")))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
-        result mustBe GetTrusteeSuccessResponse(List())
+        result mustBe GetSuccessResponse(List())
       }
     }
 
@@ -46,7 +46,7 @@ class GetTrusteesSpec extends PlaySpec with OneAppPerSuite with DESConnectorMock
           Some(Json.parse("""[{"title":"Mr","givenName":"Juan","familyName":"Doe","dateOfBirth" : "2012-04-23T18:25:43.511Z"},""" +
                           """{"title":"Mr","givenName":"Chris","familyName":"Doe","dateOfBirth" : "2012-04-23T18:25:43.511Z"}]""")))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z")),
+        result mustBe GetSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z")),
                                                     Trustee("Mr","Chris","Doe",new DateTime("2012-04-23T18:25:43.511Z"))))
       }
 
@@ -55,7 +55,7 @@ class GetTrusteesSpec extends PlaySpec with OneAppPerSuite with DESConnectorMock
         when (mockHttpGet.GET[HttpResponse](Matchers.any())(Matchers.any(),Matchers.any())).thenReturn(Future.successful(HttpResponse(200, Some(Json.parse(jsonReturn)))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
         val expectedPassport = Passport("AA12345", new DateTime("2012-04-23T18:25:43.511Z"), "ESP")
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,Some(expectedPassport))))
+        result mustBe GetSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,Some(expectedPassport))))
       }
 
       "DES returns a 200 response with a JSON array of Trustees containing a Passport when given a 'null' address" in {
@@ -63,28 +63,28 @@ class GetTrusteesSpec extends PlaySpec with OneAppPerSuite with DESConnectorMock
         when (mockHttpGet.GET[HttpResponse](Matchers.any())(Matchers.any(),Matchers.any())).thenReturn(Future.successful(HttpResponse(200, Some(Json.parse(jsonReturn)))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
         val expectedPassport = Passport("AA12345", new DateTime("2012-04-23T18:25:43.511Z"), "ESP")
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,Some(expectedPassport))))
+        result mustBe GetSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,Some(expectedPassport))))
       }
 
       "DES returns a 200 response with a JSON array of Trustees containing an Address with none of the optional parameters" in {
         val jsonReturn = """[{"title":"Mr","givenName":"Juan","familyName":"Doe","dateOfBirth" : "2012-04-23T18:25:43.511Z", "correspondenceAddress" : {"addressLine1" : "123 Any Street","isNonUkAddress" : false}}]"""
         when (mockHttpGet.GET[HttpResponse](Matchers.any())(Matchers.any(),Matchers.any())).thenReturn(Future.successful(HttpResponse(200, Some(Json.parse(jsonReturn)))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,None,Some(Address(false, "123 Any Street")))))
+        result mustBe GetSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,None,Some(Address(false, "123 Any Street")))))
       }
 
       "DES returns a 200 response with a JSON array of Trustees containing an Address with some of the optional parameters" in {
         val jsonReturn = """[{"title":"Mr","givenName":"Juan","familyName":"Doe","dateOfBirth" : "2012-04-23T18:25:43.511Z", "correspondenceAddress" : {"addressLine1" : "123 Any Street","addressLine2" : "Mowr Town","postcode" : "NE21 25A","isNonUkAddress" : false}}]"""
         when (mockHttpGet.GET[HttpResponse](Matchers.any())(Matchers.any(),Matchers.any())).thenReturn(Future.successful(HttpResponse(200, Some(Json.parse(jsonReturn)))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,None,Some(Address(false, "123 Any Street",Some("Mowr Town"),None,None,Some("NE21 25A"))))))
+        result mustBe GetSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,None,Some(Address(false, "123 Any Street",Some("Mowr Town"),None,None,Some("NE21 25A"))))))
       }
 
       "DES returns a 200 response with a JSON array of Trustees containing an Address with all the optional parameters" in {
         val jsonReturn = """[{"title":"Mr","givenName":"Juan","familyName":"Doe","dateOfBirth" : "2012-04-23T18:25:43.511Z", "correspondenceAddress" : {"addressLine1" : "123 Any Street","addressLine2" : "Mowr Town","addressLine3" : "Test","addressLine4" : "Test Test Test 523125223","postcode" : "NE21 25A","country" : "ZAR","isNonUkAddress" : false}}]"""
         when (mockHttpGet.GET[HttpResponse](Matchers.any())(Matchers.any(),Matchers.any())).thenReturn(Future.successful(HttpResponse(200, Some(Json.parse(jsonReturn)))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,None,Some(Address(false, "123 Any Street",Some("Mowr Town"),Some("Test"),Some("Test Test Test 523125223"),Some("NE21 25A"),Some("ZAR"))))))
+        result mustBe GetSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,None,Some(Address(false, "123 Any Street",Some("Mowr Town"),Some("Test"),Some("Test Test Test 523125223"),Some("NE21 25A"),Some("ZAR"))))))
       }
 
       "DES returns a 200 response with a JSON array of Trustees containing an Address and Passport" in {
@@ -92,7 +92,7 @@ class GetTrusteesSpec extends PlaySpec with OneAppPerSuite with DESConnectorMock
         when (mockHttpGet.GET[HttpResponse](Matchers.any())(Matchers.any(),Matchers.any())).thenReturn(Future.successful(HttpResponse(200, Some(Json.parse(jsonReturn)))))
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
         val expectedPassport = Passport("AA12345", new DateTime("2012-04-23T18:25:43.511Z"), "ESP")
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,Some(expectedPassport),Some(Address(false, "123 Any Street",Some("Mowr Town"),Some("Test"),Some("Test Test Test 523125223"),Some("NE21 25A"),Some("ZAR"))))))
+        result mustBe GetSuccessResponse(List(Trustee("Mr","Juan","Doe",new DateTime("2012-04-23T18:25:43.511Z"),None,None,None,None,Some(expectedPassport),Some(Address(false, "123 Any Street",Some("Mowr Town"),Some("Test"),Some("Test Test Test 523125223"),Some("NE21 25A"),Some("ZAR"))))))
       }
 
       "DES returns a 200 response with a JSON array of Trustees containing all required fields" in {
@@ -125,7 +125,7 @@ class GetTrusteesSpec extends PlaySpec with OneAppPerSuite with DESConnectorMock
         val result = Await.result(SUT.getTrustees("1234"),Duration.Inf)
         val expectedPassport = Passport("123456", new DateTime("2016-01-01T00:00:00.000Z"), "United Kingdom")
         val expectedAddress = Address(false,"A House", Some("A Street"), Some("An Area"), Some("A Town"), Some("AB1 1AB"), Some("United Kingdom"))
-        result mustBe GetTrusteeSuccessResponse(List(Trustee("Mr", "John", "Doe", new DateTime("1900-01-01T00:00:00.000Z"),Some("B"), Some("1234567890"),Some(new DateTime("2016-01-01T00:00:00.000Z")), Some("019112345678"), Some(expectedPassport), Some(expectedAddress))))
+        result mustBe GetSuccessResponse(List(Trustee("Mr", "John", "Doe", new DateTime("1900-01-01T00:00:00.000Z"),Some("B"), Some("1234567890"),Some(new DateTime("2016-01-01T00:00:00.000Z")), Some("019112345678"), Some(expectedPassport), Some(expectedAddress))))
       }
     }
 

--- a/test/uk/gov/hmrc/trustregistration/controllers/RegisterTrustControllerSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/controllers/RegisterTrustControllerSpec.scala
@@ -69,9 +69,11 @@ class RegisterTrustControllerSpec extends PlaySpec
         }
       }
     }
-    //no change tests
+  }
+
+  "No change endpoint" must {
     "return 200 ok" when {
-      "the no change endpoint is called with a valid identifier" in {
+      "the endpoint is called with a valid identifier" in {
         when(mockRegisterTrustService.noChange(any[String])(any[HeaderCarrier]))
           .thenReturn(Future.successful(SuccessResponse))
 
@@ -82,7 +84,7 @@ class RegisterTrustControllerSpec extends PlaySpec
     }
 
     "return 400" when {
-      "the no change endpoint is called with an invalid identifier" in {
+      "the endpoint is called with an invalid identifier" in {
         when(mockRegisterTrustService.noChange(any[String])(any[HeaderCarrier]))
           .thenReturn(Future.successful(BadRequestResponse))
 
@@ -112,10 +114,11 @@ class RegisterTrustControllerSpec extends PlaySpec
         status(result) mustBe NOT_FOUND
       }
     }
+  }
 
-    //Close trust test
+  "Close trusts endpoint" must {
     "return 200 ok" when {
-      "the closeTrust endpoint is called with a valid identifier" in {
+      "the endpoint is called with a valid identifier" in {
         when(mockRegisterTrustService.closeTrust(any[String])(any[HeaderCarrier]))
           .thenReturn(Future.successful(SuccessResponse))
 
@@ -126,7 +129,7 @@ class RegisterTrustControllerSpec extends PlaySpec
     }
 
     "return 400" when {
-      "the closeTrust endpoint is called with an invalid identifier" in {
+      "the endpoint is called with an invalid identifier" in {
         when(mockRegisterTrustService.closeTrust(any[String])(any[HeaderCarrier]))
           .thenReturn(Future.successful(BadRequestResponse))
 
@@ -137,7 +140,7 @@ class RegisterTrustControllerSpec extends PlaySpec
     }
 
     "return 401" when {
-      "the closeTrust endpoint is called and authentication credentials are missing or incorrect" in {
+      "the endpoint is called and authentication credentials are missing or incorrect" in {
 
         when(mockHC.headers).thenReturn(List(AUTHORIZATION -> "NOT_AUTHORISED"))
         val result = SUT.closeTrust("12345").apply(FakeRequest("PUT", ""))
@@ -147,7 +150,7 @@ class RegisterTrustControllerSpec extends PlaySpec
     }
 
     "return 404" when {
-      "the closeTrust endpoint is called and we pass an identifier that does not return a trust" in {
+      "the endpoint is called and we pass an identifier that does not return a trust" in {
         when(mockRegisterTrustService.closeTrust(any[String])(any[HeaderCarrier]))
           .thenReturn(Future.successful(NotFoundResponse))
 
@@ -156,7 +159,6 @@ class RegisterTrustControllerSpec extends PlaySpec
         status(result) mustBe NOT_FOUND
       }
     }
-
 
     "return 500" when {
       "something is broken" in {
@@ -167,11 +169,9 @@ class RegisterTrustControllerSpec extends PlaySpec
         status(result) mustBe INTERNAL_SERVER_ERROR
       }
     }
-
   }
 
   "Trustees endpoint" must {
-
     "not return a NotFound response" when {
       "the endpoint is called with a routed fake request" in {
         val result = route(FakeRequest(GET, "/trusts/1234567890/trustees"))
@@ -202,7 +202,7 @@ class RegisterTrustControllerSpec extends PlaySpec
     }
 
     "return 400" when {
-      "the closeTrust endpoint is called with an invalid identifier" in {
+      "the  endpoint is called with an invalid identifier" in {
         when(mockRegisterTrustService.getTrustees(any[String])(any[HeaderCarrier]))
           .thenReturn(Future.successful(BadRequestResponse))
 
@@ -223,7 +223,7 @@ class RegisterTrustControllerSpec extends PlaySpec
     }
 
     "return 401" when {
-      "the getTrustees endpoint is called and authentication credentials are missing or incorrect" in {
+      "the endpoint is called and authentication credentials are missing or incorrect" in {
 
         when(mockHC.headers).thenReturn(List(AUTHORIZATION -> "NOT_AUTHORISED"))
         val result = SUT.getTrustees("12345").apply(FakeRequest("GET", ""))

--- a/test/uk/gov/hmrc/trustregistration/services/RegisterTrustServiceSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/services/RegisterTrustServiceSpec.scala
@@ -61,10 +61,10 @@ class RegisterTrustServiceSpec extends PlaySpec
       }
 
       "a successful response is returned from DES for the call to getTrustees" in {
-        when(mockDesConnector.getTrustees(any())(any())).thenReturn(Future.successful(GetTrusteeSuccessResponse(Nil)))
+        when(mockDesConnector.getTrustees(any())(any())).thenReturn(Future.successful(GetSuccessResponse(Nil)))
 
         val result = Await.result(SUT.getTrustees("1234567890")(HeaderCarrier()), Duration.Inf)
-        result mustBe GetTrusteeSuccessResponse(Nil)
+        result mustBe GetSuccessResponse(Nil)
       }
     }
 


### PR DESCRIPTION
*Standarised connector result mapping inline with the rest of end points
*Used generics for GetTrusteeSuccessResponse
*case class styling for better readability
*general Unit Tests tidy up