### PR TITLE
Moved the Settlor Spec to be namespaced as per the other Specs

### DIFF
--- a/test/uk/gov/hmrc/trustregistration/models/SettlorsSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/models/SettlorsSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package Models
+package uk.gov.hmrc.trustregistration.models
 
 import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.trustregistration.models.Settlors


### PR DESCRIPTION
All other tests are under uk.gov.hmrc.trustregistration so I moved the Settlors model test there too.