### PR TITLE
REGISTER ESTATES

### DIFF
--- a/app/uk/gov/hmrc/trustregistration/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/trustregistration/connectors/DesConnector.scala
@@ -45,20 +45,26 @@ trait DesConnector extends ServicesConfig with RawResponseReads {
   lazy val desUrl = baseUrl("des")
   lazy val serviceUrl = s"$desUrl/trust-registration-stub/trusts"
 
-  def registerTrust(doc: RegistrationDocument)(implicit hc : HeaderCarrier) = {
+
+
+
+  def registerTrust(doc: TrustRegistrationDocument)(implicit hc : HeaderCarrier) = {
 
     val uri: String = s"$serviceUrl/register"
 
-    val result: Future[HttpResponse] = httpPost.POST[RegistrationDocument,HttpResponse](uri,doc)(implicitly, httpReads, implicitly)
+    val result: Future[HttpResponse] = httpPost.POST[TrustRegistrationDocument,HttpResponse](uri,doc)(implicitly, httpReads, implicitly)
 
-    result.map(f=> {
-      f.status match{
-        case 201 => Right(TRN("TRN-1234"))
-        case _ => Left("503")
-      }
-    }).recover({
-      case _ => Left("400")
-    })
+    getRegisterResponse(result)
+  }
+
+
+  def registerEstate(doc: EstateRegistrationDocument)(implicit hc : HeaderCarrier) = {
+
+    val uri: String = s"$serviceUrl/register"
+
+    val result: Future[HttpResponse] = httpPost.POST[EstateRegistrationDocument,HttpResponse](uri,doc)(implicitly, httpReads, implicitly)
+
+    getRegisterResponse(result)
   }
 
   def noChange(identifier: String)(implicit hc : HeaderCarrier): Future[ApplicationResponse] = {
@@ -312,6 +318,17 @@ trait DesConnector extends ServicesConfig with RawResponseReads {
         InternalServerErrorResponse
       }
     }
+  }
+
+  private def getRegisterResponse(result: Future[HttpResponse]): Future[Either[String, TRN] with Product with Serializable] = {
+    result.map(f => {
+      f.status match {
+        case 201 => Right(TRN("TRN-1234"))
+        case _ => Left("503")
+      }
+    }).recover({
+      case _ => Left("400")
+    })
   }
 
   def getLeadTrustee(identifier: String)(implicit hc : HeaderCarrier): Future[ApplicationResponse] = {

--- a/app/uk/gov/hmrc/trustregistration/controllers/RegisterEstateController.scala
+++ b/app/uk/gov/hmrc/trustregistration/controllers/RegisterEstateController.scala
@@ -17,14 +17,36 @@
 package uk.gov.hmrc.trustregistration.controllers
 
 import play.api.Logger
+import play.api.libs.json.{JsError, JsResult, JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.trustregistration.metrics.ApplicationMetrics
+import uk.gov.hmrc.trustregistration.models.{TRN, EstateRegistrationDocument}
 import uk.gov.hmrc.trustregistration.services.RegisterTrustService
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 
 trait RegisterEstateController extends ApplicationBaseController {
+
+  def register(): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    Logger.info("Estate Register API invoked")
+
+    val jsonBody: JsResult[EstateRegistrationDocument] = request.body.validate[EstateRegistrationDocument]
+    jsonBody.map { regDoc: EstateRegistrationDocument => {
+      val futureEither: Future[Either[String, TRN]] = registerTrustService.registerEstate(regDoc)
+      futureEither.map {
+        case Right(identifier) => Created(Json.toJson(identifier))
+        case _ => BadRequest("Error:")
+      }
+    }
+    }.recoverTotal {
+      e => {
+        Future.successful(BadRequest("Detected error:" + JsError.toFlatJson(e)))
+      }
+    }
+  }
+
   def closeEstate(identifier: String): Action[AnyContent] = Action.async{ implicit request =>
 
     Logger.info(s"$className:closeEstate API invoked")

--- a/app/uk/gov/hmrc/trustregistration/controllers/RegisterTrustController.scala
+++ b/app/uk/gov/hmrc/trustregistration/controllers/RegisterTrustController.scala
@@ -30,10 +30,10 @@ import scala.concurrent.Future
 trait RegisterTrustController extends ApplicationBaseController {
 
   def register(): Action[JsValue] = Action.async(parse.json) { implicit request =>
-    Logger.info("Register API invoked")
+    Logger.info("Trust Register API invoked")
 
-    val jsonBody: JsResult[RegistrationDocument] = request.body.validate[RegistrationDocument]
-    jsonBody.map { regDoc: RegistrationDocument => {
+    val jsonBody: JsResult[TrustRegistrationDocument] = request.body.validate[TrustRegistrationDocument]
+    jsonBody.map { regDoc: TrustRegistrationDocument => {
         val futureEither: Future[Either[String, TRN]] = registerTrustService.registerTrust(regDoc)
         futureEither.map {
           case Right(identifier) => Created(Json.toJson(identifier))

--- a/app/uk/gov/hmrc/trustregistration/models/EstateRegistrationDocument.scala
+++ b/app/uk/gov/hmrc/trustregistration/models/EstateRegistrationDocument.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.trustregistration.models
+
+import play.api.libs.json.Json
+
+case class EstateRegistrationDocument(value: String)
+
+object EstateRegistrationDocument {
+  implicit val formats = Json.format[EstateRegistrationDocument]
+}

--- a/app/uk/gov/hmrc/trustregistration/models/TrustRegistrationDocument.scala
+++ b/app/uk/gov/hmrc/trustregistration/models/TrustRegistrationDocument.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.trustregistration.models
 import play.api.libs.json.Json
 
 
-case class RegistrationDocument(value: String)
+case class TrustRegistrationDocument(value: String)
 
-object RegistrationDocument {
-  implicit val formats = Json.format[RegistrationDocument]
+object TrustRegistrationDocument {
+  implicit val formats = Json.format[TrustRegistrationDocument]
 }

--- a/app/uk/gov/hmrc/trustregistration/services/RegisterTrustService.scala
+++ b/app/uk/gov/hmrc/trustregistration/services/RegisterTrustService.scala
@@ -26,8 +26,12 @@ trait RegisterTrustService {
 
   val desConnector: DesConnector
 
-  def registerTrust(regDoc: RegistrationDocument)(implicit hc : HeaderCarrier) : Future[Either[String,TRN]] = {
+  def registerTrust(regDoc: TrustRegistrationDocument)(implicit hc : HeaderCarrier) : Future[Either[String,TRN]] = {
     desConnector.registerTrust(regDoc)(hc)
+  }
+
+  def registerEstate(regDoc: EstateRegistrationDocument)(implicit hc : HeaderCarrier) : Future[Either[String,TRN]] = {
+    desConnector.registerEstate(regDoc)(hc)
   }
 
   def noChange(identifier: String)(implicit hc: HeaderCarrier): Future[ApplicationResponse] = {

--- a/conf/live.routes
+++ b/conf/live.routes
@@ -8,4 +8,6 @@ GET        /trusts/:identifier/settlors         uk.gov.hmrc.trustregistration.co
 GET        /trusts/:identifier/natural-persons  uk.gov.hmrc.trustregistration.controllers.RegisterTrustController.getNaturalPersons(identifier: String)
 GET        /trusts/:identifier/contact-details  uk.gov.hmrc.trustregistration.controllers.RegisterTrustController.getTrustContactDetails(identifier: String)
 GET        /trusts/:identifier/lead-trustee     uk.gov.hmrc.trustregistration.controllers.RegisterTrustController.getLeadTrustee(identifier: String)
+
+POST       /estates                             uk.gov.hmrc.trustregistration.controllers.RegisterEstateController.register()
 PUT        /estates/:identifier/close           uk.gov.hmrc.trustregistration.controllers.RegisterEstateController.closeEstate(identifier: String)

--- a/test/uk/gov/hmrc/trustregistration/connectors/DES/RegisterEstateSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/connectors/DES/RegisterEstateSpec.scala
@@ -17,47 +17,45 @@
 package uk.gov.hmrc.trustregistration.connectors.DES
 
 import org.mockito.Matchers
-import org.mockito.Matchers.any
+import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.Writes
-import uk.gov.hmrc.play.http._
-import uk.gov.hmrc.trustregistration.models._
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpReads, HttpResponse, Upstream4xxResponse}
+import uk.gov.hmrc.trustregistration.models.{EstateRegistrationDocument, TRN}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
-
-class DesConnectorSpec extends PlaySpec with OneAppPerSuite with DESConnectorMocks {
-
-  "DesConnector" must {
+class RegisterEstateSpec extends PlaySpec with OneAppPerSuite with DESConnectorMocks{
+  "Register Estate endpoint" must {
     "return an identifier" when {
       "given a RegisterDocument" in {
-        when (mockHttpPost.POST[RegistrationDocument,HttpResponse](Matchers.any(),Matchers.any(),Matchers.any())
+        when (mockHttpPost.POST[EstateRegistrationDocument,HttpResponse](Matchers.any(),Matchers.any(),Matchers.any())
           (Matchers.any(),Matchers.any(),Matchers.any())).
-        thenReturn(Future.successful(HttpResponse(201)))
-        val doc = RegistrationDocument("1234")
-        val result = Await.result(SUT.registerTrust(doc),Duration.Inf)
+          thenReturn(Future.successful(HttpResponse(201)))
+        val doc = EstateRegistrationDocument("1234")
+        val result = Await.result(SUT.registerEstate(doc),Duration.Inf)
         result mustBe Right(TRN("TRN-1234"))
       }
     }
     "return a service unavailable response" when {
       "DES returns a service unavailable response " in {
-        when (mockHttpPost.POST[RegistrationDocument,HttpResponse](any[String](),any[RegistrationDocument](),any[Seq[(String,String)]]())
-          (any[Writes[RegistrationDocument]](),any[HttpReads[HttpResponse]](),any[HeaderCarrier]())).
+        when (mockHttpPost.POST[EstateRegistrationDocument,HttpResponse](any[String](),any[EstateRegistrationDocument](),any[Seq[(String,String)]]())
+          (any[Writes[EstateRegistrationDocument]](),any[HttpReads[HttpResponse]](),any[HeaderCarrier]())).
           thenReturn(Future.successful(HttpResponse(503)))
-        val doc = RegistrationDocument("1234")
-        val result = Await.result(SUT.registerTrust(doc),Duration.Inf)
+        val doc = EstateRegistrationDocument("1234")
+        val result = Await.result(SUT.registerEstate(doc),Duration.Inf)
         result mustBe Left("503")
       }
     }
     "return an exception" when {
       "Call to DES fails" in {
-        when (mockHttpPost.POST[RegistrationDocument,HttpResponse](any[String](),any[RegistrationDocument](),any[Seq[(String,String)]]())
-          (any[Writes[RegistrationDocument]](),any[HttpReads[HttpResponse]](),any[HeaderCarrier]())).
+        when (mockHttpPost.POST[EstateRegistrationDocument,HttpResponse](any[String](),any[EstateRegistrationDocument](),any[Seq[(String,String)]]())
+          (any[Writes[EstateRegistrationDocument]](),any[HttpReads[HttpResponse]](),any[HeaderCarrier]())).
           thenReturn(Future.failed(Upstream4xxResponse("Bad request",400,400)))
-        val doc = RegistrationDocument("")
-        val result = Await.result(SUT.registerTrust(doc),Duration.Inf)
+        val doc = EstateRegistrationDocument("")
+        val result = Await.result(SUT.registerEstate(doc),Duration.Inf)
         result mustBe Left("400")
       }
     }

--- a/test/uk/gov/hmrc/trustregistration/connectors/DES/RegisterTrustSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/connectors/DES/RegisterTrustSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.trustregistration.connectors.DES
+
+import org.mockito.Matchers
+import org.mockito.Matchers.any
+import org.mockito.Mockito._
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
+import play.api.libs.json.Writes
+import uk.gov.hmrc.play.http._
+import uk.gov.hmrc.trustregistration.models._
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+
+class RegisterTrustSpec extends PlaySpec with OneAppPerSuite with DESConnectorMocks {
+
+  "Register Trust endpoint" must {
+    "return an identifier" when {
+      "given a RegisterDocument" in {
+        when (mockHttpPost.POST[TrustRegistrationDocument,HttpResponse](Matchers.any(),Matchers.any(),Matchers.any())
+          (Matchers.any(),Matchers.any(),Matchers.any())).
+          thenReturn(Future.successful(HttpResponse(201)))
+        val doc = TrustRegistrationDocument("1234")
+        val result = Await.result(SUT.registerTrust(doc),Duration.Inf)
+        result mustBe Right(TRN("TRN-1234"))
+      }
+    }
+    "return a service unavailable response" when {
+      "DES returns a service unavailable response " in {
+        when (mockHttpPost.POST[TrustRegistrationDocument,HttpResponse](any[String](),any[TrustRegistrationDocument](),any[Seq[(String,String)]]())
+          (any[Writes[TrustRegistrationDocument]](),any[HttpReads[HttpResponse]](),any[HeaderCarrier]())).
+          thenReturn(Future.successful(HttpResponse(503)))
+        val doc = TrustRegistrationDocument("1234")
+        val result = Await.result(SUT.registerTrust(doc),Duration.Inf)
+        result mustBe Left("503")
+      }
+    }
+    "return an exception" when {
+      "Call to DES fails" in {
+        when (mockHttpPost.POST[TrustRegistrationDocument,HttpResponse](any[String](),any[TrustRegistrationDocument](),any[Seq[(String,String)]]())
+          (any[Writes[TrustRegistrationDocument]](),any[HttpReads[HttpResponse]](),any[HeaderCarrier]())).
+          thenReturn(Future.failed(Upstream4xxResponse("Bad request",400,400)))
+        val doc = TrustRegistrationDocument("")
+        val result = Await.result(SUT.registerTrust(doc),Duration.Inf)
+        result mustBe Left("400")
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/trustregistration/controllers/RegisterTrustControllerSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/controllers/RegisterTrustControllerSpec.scala
@@ -44,7 +44,7 @@ class RegisterTrustControllerSpec extends PlaySpec
   with RegisterTrustServiceMocks {
 
   before {
-    when(mockRegisterTrustService.registerTrust(any[RegistrationDocument])(any[HeaderCarrier]))
+    when(mockRegisterTrustService.registerTrust(any[TrustRegistrationDocument])(any[HeaderCarrier]))
       .thenReturn(Future.successful(Right(TRN("TRN-1234"))))
 
     when(mockHC.headers).thenReturn(List(AUTHORIZATION -> "AUTHORISED"))
@@ -54,7 +54,7 @@ class RegisterTrustControllerSpec extends PlaySpec
   "RegisterTrustController" must {
     "return created with a TRN" when {
       "the register endpoint is called with a valid json payload" in {
-        withCallToPOST(regDocPayload) { result =>
+        withCallToPOST(trustRegDocPayload) { result =>
           status(result) mustBe CREATED
           contentAsString(result) must include("TRN")
         }

--- a/test/uk/gov/hmrc/trustregistration/controllers/RegisterTrustServiceMocks.scala
+++ b/test/uk/gov/hmrc/trustregistration/controllers/RegisterTrustServiceMocks.scala
@@ -31,9 +31,14 @@ import scala.concurrent.Future
 
 
 trait RegisterTrustServiceMocks extends MockitoSugar {
-   val regDocPayload = Json.obj(
+   val trustRegDocPayload = Json.obj(
     "value" -> "Trust Name"
   )
+
+  val estateRegDocPayload = Json.obj(
+    "value" -> "Estate Name"
+  )
+
    val badRegDocPayload = Json.obj(
     "wrongIdentifier" -> "Trust Name"
   )

--- a/test/uk/gov/hmrc/trustregistration/services/RegisterTrustServiceSpec.scala
+++ b/test/uk/gov/hmrc/trustregistration/services/RegisterTrustServiceSpec.scala
@@ -37,11 +37,19 @@ class RegisterTrustServiceSpec extends PlaySpec
 
   "RegisterTrustService" must {
     "Return a TRN" when {
-      "Given a valid registration" in {
+      "Given a valid trust registration" in {
         when(mockDesConnector.registerTrust(any())(any())).thenReturn(Future.successful(Right(TRN(testTRN))))
-        val registration = RegistrationDocument("this is the input")
+        val registration = TrustRegistrationDocument("this is the input")
 
         val result = Await.result(SUT.registerTrust(registration)(HeaderCarrier()), Duration.Inf)
+        result mustBe Right(TRN(testTRN))
+      }
+
+      "Given a valid estate registration" in {
+        when(mockDesConnector.registerEstate(any())(any())).thenReturn(Future.successful(Right(TRN(testTRN))))
+        val registration = EstateRegistrationDocument("this is the input")
+
+        val result = Await.result(SUT.registerEstate(registration)(HeaderCarrier()), Duration.Inf)
         result mustBe Right(TRN(testTRN))
       }
     }


### PR DESCRIPTION
*Added register estate functionality at controller, service and connector level
*Tests to cover the new functionality
*Refactor to acommodate existing functionality to be consumed now by both RegisterTrusts and RegisterEstates