### PR TITLE
Attempted fix for NoClassDef exception when running API through servi…

### DIFF
--- a/app/uk/gov/hmrc/trustregistration/controllers/RegisterTrustController.scala
+++ b/app/uk/gov/hmrc/trustregistration/controllers/RegisterTrustController.scala
@@ -129,6 +129,6 @@ trait RegisterTrustController extends ApplicationBaseController {
 
 object RegisterTrustController extends RegisterTrustController {
   override val registerTrustService = RegisterTrustService
-  override val jsonSchemaValidator = JsonSchemaValidator
+  override lazy val jsonSchemaValidator = JsonSchemaValidator
   override val metrics = ApplicationMetrics
 }

--- a/app/uk/gov/hmrc/trustregistration/utils/JsonSchemaValidator.scala
+++ b/app/uk/gov/hmrc/trustregistration/utils/JsonSchemaValidator.scala
@@ -92,5 +92,5 @@ trait JsonSchemaValidator {
 }
 
 object JsonSchemaValidator extends JsonSchemaValidator {
-  val schema: JsonNode = JsonLoader.fromPath("public/api/conf/2.0/schemas/trustestate.json")
+  lazy val schema: JsonNode = JsonLoader.fromPath("public/api/conf/2.0/schemas/trustestate.json")
 }


### PR DESCRIPTION
…ce manager

Traced error back to a null pointer on the SchemaValidator when instantiating the
trust registration controller. Made the val lazy in an attempt to allow it to instantiate
correctly without this yet being present.