### PR TITLE
Added schema validation for protector and settlors cross field

### DIFF
--- a/public/api/conf/2.0/schemas/trustestate.json
+++ b/public/api/conf/2.0/schemas/trustestate.json
@@ -1060,22 +1060,52 @@
     },
     "protectorsType": {
       "description": "protectors Type",
-      "additionalProperties": false,
-      "properties": {
-        "companies": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/companyType"
-          }
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "companies": {
+              "type": "array",
+              "maxItems": 1,
+              "items": {
+                "$ref": "#/definitions/companyType"
+              }
+            },
+            "individuals": {
+              "type": "array",
+              "maxItems": 1,
+              "items": {
+                "$ref": "#/definitions/individualType"
+              }
+            }
+          },
+          "additionalProperties": false
         },
-        "individuals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/individualType"
-          }
+        {
+          "properties": {
+            "companies": {
+              "type": "array",
+              "maxItems": 2,
+              "items": {
+                "$ref": "#/definitions/companyType"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "individuals": {
+              "type": "array",
+              "maxItems": 2,
+              "items": {
+                "$ref": "#/definitions/individualType"
+              }
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "type": "object"
+      ]
     },
     "residentTypeType": {
       "description": "Possible Domiciles\n\t\t\tCode   Title\n\t\t\t----   -----\n\t\t\t0001   Settlor domiciled Trustees nonresident\n\t\t\t0002   Settlor non domiciled becomes domiciled then resident\n\t\t\t0003   Trustee ceases to be resident\n\t\t",
@@ -1098,21 +1128,49 @@
     },
     "settlorsType": {
       "description": "Settlors Type",
-      "additionalProperties": false,
-      "properties": {
-        "companies": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/companyType"
-          }
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "companies": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/companyType"
+              }
+            },
+            "individuals": {
+              "type": "array",
+              "minItems": 0,
+              "items": {
+                "$ref": "#/definitions/individualType"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": ["companies"]
         },
-        "individuals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/individualType"
-          }
+        {
+          "properties": {
+            "companies": {
+              "type": "array",
+              "minItems": 0,
+              "items": {
+                "$ref": "#/definitions/companyType"
+              }
+            },
+            "individuals": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/individualType"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": ["individuals"]
         }
-      }
+      ]
     },
     "shareAssetsType": {
       "description": "Share Assets Type",
@@ -1250,7 +1308,8 @@
       "required" : [
         "name",
         "telephoneNumber",
-        "leadTrustee"
+        "leadTrustee",
+        "settlors"
       ]
     },
     "trusteesType": {


### PR DESCRIPTION
* Can have 0-2 protectors in any mix of companies and individuals.
* Can have 1-infinite settlors in any mix of companies and individuals.